### PR TITLE
Refactor Gst imports and add abstract base class

### DIFF
--- a/protorec/__init__.py
+++ b/protorec/__init__.py
@@ -16,9 +16,7 @@ import cv2  # type: ignore
 import numpy as np
 from flask import Flask, Response, jsonify, render_template
 
-from protorec.pipelines import Gst as Gst
-from protorec.pipelines.rgb_pipeline import RGBPipeline
-from protorec.pipelines.thermal_pipeline import ThermalPipeline
+from protorec.pipelines import RGBPipeline, ThermalPipeline
 
 __version__ = "0.2.0"
 
@@ -57,9 +55,7 @@ class CameraManager:
     and frame retrieval for streaming.
     """
 
-    def __init__(
-        self, config_path: str, recdir: str, streaming_camera: str = "rgb"
-    ) -> None:
+    def __init__(self, config_path: str, recdir: str) -> None:
         """Initialize the camera manager.
 
         Parameters
@@ -68,8 +64,6 @@ class CameraManager:
             Path to camera configuration JSON file
         recdir : str
             Directory to store recordings
-        streaming_camera : str, optional
-            Name of camera to use for streaming, by default "rgb"
         """
         self.is_recording: bool = False
         self.recdir: str = recdir

--- a/protorec/pipelines/__init__.py
+++ b/protorec/pipelines/__init__.py
@@ -1,14 +1,32 @@
 """GStreamer pipeline initialization and common imports."""
 
+import logging
+
+from .pipeline_abc import BasePipeline
+
+# get or connect to existing logger
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
 try:
     import gi
 
     gi.require_version("Gst", "1.0")
     gi.require_version("GstApp", "1.0")
     from gi.repository import Gst
-except ImportError as e:
-    raise ImportError(
-        "GStreamer Python bindings not found. Please install gstreamer1.0-python3"
-    ) from e
 
-__all__ = ["Gst"]
+    from .rgb_pipeline import RGBPipeline
+    from .thermal_pipeline import ThermalPipeline
+except ImportError:
+    logger.warning(
+        "GStreamer Python bindings not found. Please install gstreamer1.0-python3"
+    )
+
+    class RGBPipeline(BasePipeline):
+        """Dummy RGB pipeline implementation."""
+
+    class ThermalPipeline(BasePipeline):  # type: ignore
+        """Dummy thermal pipeline implementation."""
+
+
+__all__ = ["Gst", "RGBPipeline", "ThermalPipeline"]

--- a/protorec/pipelines/pipeline.py
+++ b/protorec/pipelines/pipeline.py
@@ -7,10 +7,11 @@ setup and control for video recording from different camera types.
 import os
 from typing import Any, Dict, Optional
 
-from protorec.pipelines import Gst
+from . import Gst
+from .pipeline_abc import BasePipeline
 
 
-class CameraPipeline:
+class CameraPipeline(BasePipeline):
     """Base class for camera pipeline handling.
 
     This class provides the basic structure and methods for creating and

--- a/protorec/pipelines/pipeline_abc.py
+++ b/protorec/pipelines/pipeline_abc.py
@@ -1,0 +1,35 @@
+"""Abstract base class for camera pipeline handling."""
+
+import abc
+
+
+class BasePipeline(abc.ABC):
+    """Abstract base class for camera pipeline handling.
+
+    This class provides the basic interface that all pipeline implementations
+    must follow.
+    """
+
+    @abc.abstractmethod
+    def construct_pipeline(self):
+        """Construct the GStreamer pipeline."""
+
+    @abc.abstractmethod
+    def run(self) -> None:
+        """Run the pipeline."""
+
+    @abc.abstractmethod
+    def stop(self) -> None:
+        """Stop the pipeline."""
+
+    @abc.abstractmethod
+    def is_playing(self) -> bool:
+        """Check if pipeline is playing."""
+
+    @abc.abstractmethod
+    def is_stopped(self) -> bool:
+        """Check if pipeline is stopped."""
+
+    @abc.abstractmethod
+    def set_dir(self, dir_path: str) -> None:
+        """Set output directory."""


### PR DESCRIPTION
## What?
 
Allow git actions to fetch the `__version__` of the package without running into import problems.
 
## Why?
 
Makes automation smoother.
 
## How?
 
- Create BasePipeline abstract base class in pipeline_abc.py
- Centralize pipeline imports in pipelines/__init__.py
- Remove streaming_camera parameter from CameraManager
- Add fallback dummy pipeline classes for import errors
- Improve error handling and logging for GStreamer imports